### PR TITLE
Fixing buttons bug, and adding a new logic for items edit button, and a fix to the complete shopping button

### DIFF
--- a/starving.xcodeproj/project.pbxproj
+++ b/starving.xcodeproj/project.pbxproj
@@ -451,7 +451,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = starving/starving.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"starving/Preview Content\"";
 				DEVELOPMENT_TEAM = F26L3GH72M;
 				ENABLE_PREVIEWS = YES;
@@ -462,7 +462,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hvaandres.starving;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -484,7 +484,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = starving/starving.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 13;
 				DEVELOPMENT_ASSET_PATHS = "\"starving/Preview Content\"";
 				DEVELOPMENT_TEAM = F26L3GH72M;
 				ENABLE_PREVIEWS = YES;
@@ -495,7 +495,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1;
+				MARKETING_VERSION = 2.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hvaandres.starving;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/starving/Views/ItemsView.swift
+++ b/starving/Views/ItemsView.swift
@@ -353,8 +353,7 @@ struct ItemsView: View {
                         toggleItem(item)
                     }
                     .listRowInsets(EdgeInsets(top: 0, leading: 20, bottom: 0, trailing: 20))
-                    .listRowSeparator(.visible)
-                    .listRowSeparatorTint(Color.secondary.opacity(0.3))
+                    .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                         Button(role: .destructive) {
@@ -573,11 +572,19 @@ struct ItemsView: View {
             // Action buttons
             HStack(spacing: 8) {
                 // Save button
-                Button(action: { saveEdit() }) {
+                Button(action: { 
+                    // Properly dismiss keyboard
+                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                    // Save immediately after dismissing
+                    DispatchQueue.main.async {
+                        saveEdit()
+                    }
+                }) {
                     Image(systemName: "checkmark")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.white)
                         .frame(width: 44, height: 44)
+                        .contentShape(Circle())
                         .background(
                             Circle()
                                 .fill(
@@ -590,6 +597,7 @@ struct ItemsView: View {
                         )
                         .shadow(color: Color.blue.opacity(0.3), radius: 8, x: 0, y: 4)
                 }
+                .buttonStyle(PlainButtonStyle())
                 .disabled(editedTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 .opacity(editedTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.5 : 1.0)
                 

--- a/starving/Views/TodayView.swift
+++ b/starving/Views/TodayView.swift
@@ -45,7 +45,7 @@ struct TodayView: View {
     
     // MARK: - Body
     var body: some View {
-        ZStack(alignment: .bottom) {
+        ZStack {
             Color(.systemBackground)
                 .ignoresSafeArea()
             
@@ -64,11 +64,11 @@ struct TodayView: View {
                 } else {
                     emptyStateView
                 }
-            }
-            
-            // Complete button at bottom - only show when items are selected
-            if hasItemsToday && !completedItems.isEmpty {
-                completeButton
+                
+                // Complete button at bottom - only show when items are selected
+                if hasItemsToday && !completedItems.isEmpty {
+                    completeButton
+                }
             }
         }
         .overlay {
@@ -118,13 +118,6 @@ struct TodayView: View {
                                 accentColor: .green
                             )
                             .padding(.horizontal, 20)
-                            
-                            if item.id != myItems.last?.id {
-                                Divider()
-                                    .padding(.leading, 60)
-                                    .padding(.trailing, 20)
-                                    .opacity(0.3)
-                            }
                         }
                     }
                 }
@@ -146,19 +139,11 @@ struct TodayView: View {
                                 onDelete: { removeItem(item) }
                             )
                             .padding(.horizontal, 20)
-                            
-                            if item.id != sharedWithMeItems.last?.id {
-                                Divider()
-                                    .padding(.leading, 60)
-                                    .padding(.trailing, 20)
-                                    .opacity(0.3)
-                            }
                         }
                     }
                 }
             }
             .padding(.vertical, 8)
-            .padding(.bottom, 100)
         }
     }
     
@@ -283,7 +268,8 @@ struct TodayView: View {
         }
         .disabled(!allItemsCompleted)
         .padding(.horizontal, 20)
-        .padding(.bottom, 100) // Increased from 20 to 100 to avoid tab bar overlap
+        .padding(.top, 12)
+        .padding(.bottom, 20)
     }
     
     // MARK: - Helper Methods


### PR DESCRIPTION
Bug Fixes Summary

1. Edit Button Save Issue (ItemsView)
Problem: The checkmark button to save edits wasn't working when tapped directly - only worked when pressing Enter on the keyboard.

Solution: 
•  Added proper keyboard dismissal using UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), ...)
•  Wrapped saveEdit() in DispatchQueue.main.async to ensure it executes after keyboard dismissal completes
•  Added .contentShape(Circle()) to make the entire button area tappable
•  Added .buttonStyle(PlainButtonStyle()) to prevent default button behavior from interfering with taps in a List

File Modified: starving/Views/ItemsView.swift (lines 575-600)

2. Complete Shopping Button Overlap Issue (TodayView)
Problem: The "Complete Shopping" button was positioned on top of items in a ZStack overlay, making items unclickable when there were 20+ items.

Solution:
•  Removed button from top-level ZStack overlay
•  Moved button into the main VStack flow, placing it after the itemsList
•  Added proper spacing with 12px top padding and 20px bottom padding
•  Button now sits naturally at the bottom of the container, just above the tab bar, without overlapping scrollable content

Files Modified: starving/Views/TodayView.swift (lines 68-71, 103-161, 284-286)

3. Separator Lines Removed
Problem: Unwanted divider lines were appearing between items in both ItemsView and TodayView.

Solution:
•  ItemsView: Changed .listRowSeparator(.visible) to .listRowSeparator(.hidden) and removed .listRowSeparatorTint()
•  TodayView: Removed all Divider() components from the ForEach loops in both "My Items" and "Shared With Me" sections

Files Modified: 
•  starving/Views/ItemsView.swift (line 356)
•  starving/Views/TodayView.swift (removed lines with Divider in both item sections)